### PR TITLE
Make Theme initializer public

### DIFF
--- a/src/classes/Theme.swift
+++ b/src/classes/Theme.swift
@@ -49,7 +49,7 @@ open class Theme {
      
      - parameter themeString: Theme to use.
      */
-    init(themeString: String)
+    public init(themeString: String)
     {
         theme = themeString
         setCodeFont(RPFont(name: "Courier", size: 14)!)


### PR DESCRIPTION
Allows one to override setTheme(to:) of Highlightr class to provide a custom themeString to Theme initializer.  

Custom themeString can then be obtained from a minimized css file in app bundle.

Without the initializer being public, the setTheme(to:) override can't access the Theme initializer.