### PR TITLE
Update Theme.swift

### DIFF
--- a/src/classes/Theme.swift
+++ b/src/classes/Theme.swift
@@ -149,6 +149,14 @@ open class Theme {
                     style = "hljs-class-hljs-title"
                 }
 
+                if styleList.contains("hljs-title class_") && themeDict["hljs-title-class"] != nil {
+                    style = "hljs-title-class"
+                }
+
+                if styleList.contains("hljs-title class_ inherited__") && themeDict["hljs-title-class-inherited"] != nil {
+                    style = "hljs-title-class-inherited"
+                }
+
                 if let themeStyle = themeDict[style] as? [AttributedStringKey: Any]
                 {
                     for (attrName, attrValue) in themeStyle


### PR DESCRIPTION
Added support to highlight new CSS classes:

// Ex:  "ExampleView" in  struct ExampleView: View "hljs-title class_"    

// Ex:  "View" in  struct ExampleView: View
"hljs-title class_ inherited__"

Corresponding new theme dict keys are "hljs-title-class" and "hljs-title-class-inherited" respectively.